### PR TITLE
feat(ai): add initial ai chatbot frontend

### DIFF
--- a/client/app/ai/components/ChatHeader.tsx
+++ b/client/app/ai/components/ChatHeader.tsx
@@ -17,20 +17,20 @@ const ChatHeader = ({
   actions,
 }: ChatHeaderProps) => {
   return (
-    <header className="flex items-center justify-between border-b border-white/10 bg-black/40 px-4 py-4 backdrop-blur-md lg:px-10">
+    <header className="flex items-center justify-between border-b border-[#F2D8C3] bg-white/90 px-4 py-4 backdrop-blur-md lg:px-10">
       <div className="flex items-center gap-3">
         {onToggleSidebar && (
           <button
             type="button"
             onClick={onToggleSidebar}
-            className="rounded-lg bg-white/10 p-2 text-white transition hover:bg-white/20 lg:hidden"
+            className="rounded-lg border border-[#F2D8C3] bg-white p-2 text-gray-600 transition hover:bg-[#FFF1E6] lg:hidden"
             aria-label="Toggle sidebar"
           >
             <Menu className="h-5 w-5" />
           </button>
         )}
         <div>
-          <h1 className="text-xl font-semibold text-white md:text-2xl">
+          <h1 className="text-xl font-semibold text-gray-900 md:text-2xl">
             {title}
           </h1>
           {subtitle && (

--- a/client/app/ai/components/ChatHeader.tsx
+++ b/client/app/ai/components/ChatHeader.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { Menu } from "lucide-react";
+
+interface ChatHeaderProps {
+  title: string;
+  subtitle?: string;
+  onToggleSidebar?: () => void;
+  actions?: ReactNode;
+}
+
+const ChatHeader = ({
+  title,
+  subtitle,
+  onToggleSidebar,
+  actions,
+}: ChatHeaderProps) => {
+  return (
+    <header className="flex items-center justify-between border-b border-white/10 bg-black/40 px-4 py-4 backdrop-blur-md lg:px-10">
+      <div className="flex items-center gap-3">
+        {onToggleSidebar && (
+          <button
+            type="button"
+            onClick={onToggleSidebar}
+            className="rounded-lg bg-white/10 p-2 text-white transition hover:bg-white/20 lg:hidden"
+            aria-label="Toggle sidebar"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        )}
+        <div>
+          <h1 className="text-xl font-semibold text-white md:text-2xl">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="text-xs font-medium uppercase tracking-[0.3em] text-[#FC7019]">
+              {subtitle}
+            </p>
+          )}
+        </div>
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </header>
+  );
+};
+
+export default ChatHeader;

--- a/client/app/ai/components/ChatInput.tsx
+++ b/client/app/ai/components/ChatInput.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Globe, Send } from "lucide-react";
+
+interface ChatInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  isLoading: boolean;
+  webSearchEnabled: boolean;
+  onToggleWebSearch: () => void;
+}
+
+const ChatInput = ({
+  value,
+  onChange,
+  onSend,
+  isLoading,
+  webSearchEnabled,
+  onToggleWebSearch,
+}: ChatInputProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [value]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      onSend();
+    }
+  };
+
+  return (
+    <div className="border-t border-white/10 bg-black/60 px-3 py-4 backdrop-blur-md md:px-10">
+      <div className="mx-auto flex max-w-3xl flex-col gap-3 rounded-3xl bg-white/5 p-4">
+        <div className="flex items-start gap-3">
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about scholarships, application requirements, timelines..."
+            className="flex-1 resize-none rounded-2xl border border-white/10 bg-black/40 px-3 py-3 text-sm text-white shadow-inner focus:border-[#FC7019] focus:outline-none"
+            rows={1}
+            maxLength={1200}
+            disabled={isLoading}
+          />
+          <button
+            type="button"
+            onClick={onSend}
+            disabled={isLoading || value.trim().length === 0}
+            className={`flex h-12 w-12 items-center justify-center rounded-full text-black transition ${
+              isLoading || value.trim().length === 0
+                ? "bg-white/30 text-black/40"
+                : "bg-[#FC7019] hover:bg-white"
+            }`}
+            aria-label="Send message"
+          >
+            <Send className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="flex items-center justify-between text-xs text-white/60">
+          <button
+            type="button"
+            onClick={onToggleWebSearch}
+            className={`flex items-center gap-2 rounded-full border px-3 py-1 transition ${
+              webSearchEnabled
+                ? "border-[#FC7019] bg-[#FC7019]/20 text-[#FC7019]"
+                : "border-white/20 hover:border-[#FC7019] hover:text-white"
+            }`}
+          >
+            <Globe className="h-3.5 w-3.5" />
+            Web search {webSearchEnabled ? "enabled" : "disabled"}
+          </button>
+          <p className="text-right text-[11px] uppercase tracking-[0.2em]">
+            Shift + Enter to add a line
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/client/app/ai/components/ChatInput.tsx
+++ b/client/app/ai/components/ChatInput.tsx
@@ -40,16 +40,16 @@ const ChatInput = ({
   };
 
   return (
-    <div className="border-t border-white/10 bg-black/60 px-3 py-4 backdrop-blur-md md:px-10">
-      <div className="mx-auto flex max-w-3xl flex-col gap-3 rounded-3xl bg-white/5 p-4">
+    <div className="border-t border-[#F2D8C3] bg-white/90 px-3 py-4 backdrop-blur-md md:px-10">
+      <div className="mx-auto flex max-w-3xl flex-col gap-3 rounded-3xl border border-[#F2D8C3] bg-white p-4 shadow-sm">
         <div className="flex items-start gap-3">
           <textarea
             ref={textareaRef}
             value={value}
             onChange={(event) => onChange(event.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Ask about scholarships, application requirements, timelines..."
-            className="flex-1 resize-none rounded-2xl border border-white/10 bg-black/40 px-3 py-3 text-sm text-white shadow-inner focus:border-[#FC7019] focus:outline-none"
+            placeholder="Describe your community energy goals, available resources, or rollout timeline..."
+            className="flex-1 resize-none rounded-2xl border border-[#F2D8C3] bg-white px-3 py-3 text-sm text-gray-900 shadow-inner focus:border-[#FC7019] focus:outline-none"
             rows={1}
             maxLength={1200}
             disabled={isLoading}
@@ -58,24 +58,24 @@ const ChatInput = ({
             type="button"
             onClick={onSend}
             disabled={isLoading || value.trim().length === 0}
-            className={`flex h-12 w-12 items-center justify-center rounded-full text-black transition ${
+            className={`flex h-12 w-12 items-center justify-center rounded-full transition ${
               isLoading || value.trim().length === 0
-                ? "bg-white/30 text-black/40"
-                : "bg-[#FC7019] hover:bg-white"
+                ? "bg-gray-200 text-gray-400"
+                : "bg-[#FC7019] text-white hover:bg-[#E8620F]"
             }`}
             aria-label="Send message"
           >
             <Send className="h-5 w-5" />
           </button>
         </div>
-        <div className="flex items-center justify-between text-xs text-white/60">
+        <div className="flex items-center justify-between text-xs text-gray-500">
           <button
             type="button"
             onClick={onToggleWebSearch}
             className={`flex items-center gap-2 rounded-full border px-3 py-1 transition ${
               webSearchEnabled
-                ? "border-[#FC7019] bg-[#FC7019]/20 text-[#FC7019]"
-                : "border-white/20 hover:border-[#FC7019] hover:text-white"
+                ? "border-[#FC7019] bg-[#FFF1E6] text-[#FC7019]"
+                : "border-[#F2D8C3] text-gray-600 hover:border-[#FC7019] hover:text-[#FC7019]"
             }`}
           >
             <Globe className="h-3.5 w-3.5" />

--- a/client/app/ai/components/ChatMessageList.tsx
+++ b/client/app/ai/components/ChatMessageList.tsx
@@ -31,21 +31,21 @@ const ChatMessageList = ({
     <div className="flex-1 overflow-y-auto px-3 py-6 md:px-10">
       <div className="mx-auto flex max-w-3xl flex-col gap-6">
         {messages.length === 0 && !isLoading ? (
-          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-center text-white">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[#FC7019]/20 text-[#FC7019]">
+          <div className="rounded-3xl border border-[#F2D8C3] bg-white p-6 text-center text-gray-900 shadow-sm">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[#FC7019]/15 text-[#FC7019]">
               <Bot className="h-5 w-5" />
             </div>
             <h2 className="mt-4 text-2xl font-semibold">Welcome to IslaBot</h2>
-            <p className="mt-2 text-sm text-white/70">
-              Ask about scholarships, requirements, deadlines, or how to
-              navigate college opportunities.
+            <p className="mt-2 text-sm text-gray-600">
+              Plan IslaGrid deployments, analyze renewable resources, and map
+              out community-wide energy benefits.
             </p>
             <div className="mt-6 grid gap-3 md:grid-cols-2">
               {suggestions.map((suggestion) => (
                 <button
                   key={suggestion}
                   onClick={() => onSuggestionPick(suggestion)}
-                  className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-left text-sm text-white transition hover:border-[#FC7019] hover:bg-[#FC7019]/10"
+                  className="rounded-2xl border border-[#F2D8C3] bg-white px-4 py-3 text-left text-sm text-gray-800 transition hover:border-[#FC7019] hover:bg-[#FFF1E6]"
                   type="button"
                 >
                   {suggestion}
@@ -68,8 +68,8 @@ const ChatMessageList = ({
                   <div
                     className={`relative max-w-[90%] rounded-3xl px-4 py-3 text-sm md:text-base ${
                       isAssistant
-                        ? "bg-white/10 text-white"
-                        : "bg-[#FC7019] text-black"
+                        ? "bg-[#FFF5EB] text-gray-900 border border-[#F2D8C3]"
+                        : "bg-[#FC7019] text-white shadow"
                     }`}
                   >
                     <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
@@ -78,7 +78,7 @@ const ChatMessageList = ({
                           <Bot className="h-4 w-4" />
                           <span>IslaBot</span>
                           {message.usedSearch && (
-                            <span className="flex items-center gap-1 rounded-full bg-black/30 px-2 py-0.5 text-[10px]">
+                            <span className="flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 text-[10px] text-gray-800">
                               <Globe className="h-3 w-3" /> Web Search
                             </span>
                           )}
@@ -105,7 +105,7 @@ const ChatMessageList = ({
                     {isAssistant &&
                       message.references &&
                       message.references.length > 0 && (
-                        <div className="mt-3 rounded-2xl bg-black/40 p-3 text-xs text-white/80">
+                        <div className="mt-3 rounded-2xl border border-[#F2D8C3] bg-white p-3 text-xs text-gray-700">
                           <p className="mb-2 font-semibold uppercase tracking-wide text-[#FC7019]">
                             References
                           </p>
@@ -113,7 +113,7 @@ const ChatMessageList = ({
                             {message.references.map((reference) => (
                               <li key={reference.url}>
                                 <a
-                                  className="text-white/80 underline-offset-2 hover:text-white hover:underline"
+                                  className="text-[#1F3A5F] underline-offset-2 hover:text-[#FC7019] hover:underline"
                                   href={reference.url}
                                   rel="noreferrer"
                                   target="_blank"
@@ -130,7 +130,7 @@ const ChatMessageList = ({
                       <button
                         type="button"
                         onClick={() => onCopyMessage?.(message.id)}
-                        className="mt-3 flex items-center gap-2 text-xs uppercase tracking-wide text-white/70 transition hover:text-white"
+                        className="mt-3 flex items-center gap-2 text-xs uppercase tracking-wide text-[#FC7019] transition hover:text-[#D85505]"
                       >
                         <Copy className="h-3.5 w-3.5" /> Copy
                       </button>
@@ -144,7 +144,7 @@ const ChatMessageList = ({
 
         {isLoading && (
           <div className="flex justify-start">
-            <div className="flex items-center gap-3 rounded-3xl bg-white/10 px-4 py-3 text-sm text-white">
+            <div className="flex items-center gap-3 rounded-3xl border border-[#F2D8C3] bg-white px-4 py-3 text-sm text-gray-700 shadow-sm">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span>
                 {webSearchEnabled

--- a/client/app/ai/components/ChatMessageList.tsx
+++ b/client/app/ai/components/ChatMessageList.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { Fragment, useEffect, useRef } from "react";
+import { Bot, Copy, Globe, Loader2, User } from "lucide-react";
+import { type ChatMessage } from "./types";
+
+interface ChatMessageListProps {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  suggestions: string[];
+  onSuggestionPick: (suggestion: string) => void;
+  onCopyMessage?: (messageId: string) => void;
+  webSearchEnabled: boolean;
+}
+
+const ChatMessageList = ({
+  messages,
+  isLoading,
+  suggestions,
+  onSuggestionPick,
+  onCopyMessage,
+  webSearchEnabled,
+}: ChatMessageListProps) => {
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoading]);
+
+  return (
+    <div className="flex-1 overflow-y-auto px-3 py-6 md:px-10">
+      <div className="mx-auto flex max-w-3xl flex-col gap-6">
+        {messages.length === 0 && !isLoading ? (
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-center text-white">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[#FC7019]/20 text-[#FC7019]">
+              <Bot className="h-5 w-5" />
+            </div>
+            <h2 className="mt-4 text-2xl font-semibold">Welcome to IslaBot</h2>
+            <p className="mt-2 text-sm text-white/70">
+              Ask about scholarships, requirements, deadlines, or how to
+              navigate college opportunities.
+            </p>
+            <div className="mt-6 grid gap-3 md:grid-cols-2">
+              {suggestions.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  onClick={() => onSuggestionPick(suggestion)}
+                  className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-left text-sm text-white transition hover:border-[#FC7019] hover:bg-[#FC7019]/10"
+                  type="button"
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <Fragment>
+            {messages.map((message) => {
+              const isAssistant = message.role === "assistant";
+
+              return (
+                <div
+                  key={message.id}
+                  className={`flex ${
+                    isAssistant ? "justify-start" : "justify-end"
+                  }`}
+                >
+                  <div
+                    className={`relative max-w-[90%] rounded-3xl px-4 py-3 text-sm md:text-base ${
+                      isAssistant
+                        ? "bg-white/10 text-white"
+                        : "bg-[#FC7019] text-black"
+                    }`}
+                  >
+                    <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+                      {isAssistant ? (
+                        <>
+                          <Bot className="h-4 w-4" />
+                          <span>IslaBot</span>
+                          {message.usedSearch && (
+                            <span className="flex items-center gap-1 rounded-full bg-black/30 px-2 py-0.5 text-[10px]">
+                              <Globe className="h-3 w-3" /> Web Search
+                            </span>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          <span>You</span>
+                          <User className="h-4 w-4" />
+                        </>
+                      )}
+                    </div>
+
+                    <div className="text-sm leading-relaxed md:text-base">
+                      {message.content.split("\n").map((line, index) => (
+                        <p
+                          key={`${message.id}-${index}`}
+                          className="mb-2 last:mb-0"
+                        >
+                          {line}
+                        </p>
+                      ))}
+                    </div>
+
+                    {isAssistant &&
+                      message.references &&
+                      message.references.length > 0 && (
+                        <div className="mt-3 rounded-2xl bg-black/40 p-3 text-xs text-white/80">
+                          <p className="mb-2 font-semibold uppercase tracking-wide text-[#FC7019]">
+                            References
+                          </p>
+                          <ul className="space-y-1">
+                            {message.references.map((reference) => (
+                              <li key={reference.url}>
+                                <a
+                                  className="text-white/80 underline-offset-2 hover:text-white hover:underline"
+                                  href={reference.url}
+                                  rel="noreferrer"
+                                  target="_blank"
+                                >
+                                  {reference.title ?? reference.url}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                    {isAssistant && (
+                      <button
+                        type="button"
+                        onClick={() => onCopyMessage?.(message.id)}
+                        className="mt-3 flex items-center gap-2 text-xs uppercase tracking-wide text-white/70 transition hover:text-white"
+                      >
+                        <Copy className="h-3.5 w-3.5" /> Copy
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </Fragment>
+        )}
+
+        {isLoading && (
+          <div className="flex justify-start">
+            <div className="flex items-center gap-3 rounded-3xl bg-white/10 px-4 py-3 text-sm text-white">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>
+                {webSearchEnabled
+                  ? "Searching the web for the latest results..."
+                  : "Thinking through the best answer for you..."}
+              </span>
+            </div>
+          </div>
+        )}
+        <div ref={endRef} />
+      </div>
+    </div>
+  );
+};
+
+export default ChatMessageList;

--- a/client/app/ai/components/ChatMessageList.tsx
+++ b/client/app/ai/components/ChatMessageList.tsx
@@ -94,7 +94,7 @@ const ChatMessageList = ({
                     <div className="text-sm leading-relaxed md:text-base">
                       {message.content.split("\n").map((line, index) => (
                         <p
-                          key={`${message.id}-${index}`}
+                          key={index}
                           className="mb-2 last:mb-0"
                         >
                           {line}

--- a/client/app/ai/components/ChatSidebar.tsx
+++ b/client/app/ai/components/ChatSidebar.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { type ConversationPreview } from "./types";
+import { Plus, Trash2 } from "lucide-react";
+
+interface ChatSidebarProps {
+  conversations: ConversationPreview[];
+  currentConversationId: string;
+  onSelectConversation: (conversationId: string) => void;
+  onCreateConversation: () => void;
+  onDeleteConversation: (conversationId: string) => void;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ChatSidebar = ({
+  conversations,
+  currentConversationId,
+  onSelectConversation,
+  onCreateConversation,
+  onDeleteConversation,
+  isOpen,
+  onClose,
+}: ChatSidebarProps) => {
+  return (
+    <aside
+      className={`fixed inset-y-0 left-0 z-30 w-72 bg-[#0E0E0E] border-r border-white/10 transition-transform duration-300 lg:relative lg:translate-x-0 ${
+        isOpen ? "translate-x-0" : "-translate-x-full"
+      }`}
+    >
+      <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+          <div>
+            <p className="text-xs font-medium uppercase text-white/60 tracking-[0.2em]">
+              IslaGrid
+            </p>
+            <h2 className="text-lg font-semibold text-white">IslaBot AI</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="lg:hidden text-white/50 hover:text-white"
+            aria-label="Close sidebar"
+          >
+            X
+          </button>
+        </div>
+
+        <div className="px-5 py-4">
+          <button
+            type="button"
+            onClick={onCreateConversation}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#FC7019] px-3 py-2 text-sm font-semibold text-black transition hover:bg-white"
+          >
+            <Plus className="h-4 w-4" />
+            New Conversation
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-3 pb-6">
+          <ul className="space-y-2">
+            {conversations.map((conversation) => {
+              const isActive = conversation.id === currentConversationId;
+
+              return (
+                <li key={conversation.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectConversation(conversation.id)}
+                    className={`group flex w-full items-start justify-between rounded-xl px-4 py-3 text-left transition ${
+                      isActive
+                        ? "bg-white text-black"
+                        : "bg-white/5 text-white hover:bg-white/10"
+                    }`}
+                  >
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold">
+                          {conversation.title}
+                        </span>
+                        {conversation.pinned && (
+                          <span className="rounded-full bg-[#FC7019]/20 px-2 text-[10px] font-semibold uppercase tracking-wide text-[#FC7019]">
+                            Pinned
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 line-clamp-2 text-xs opacity-70">
+                        {conversation.lastMessage}
+                      </p>
+                      <p className="mt-2 text-[11px] uppercase tracking-wider text-white/50">
+                        {conversation.updatedAt}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onDeleteConversation(conversation.id);
+                      }}
+                      className={`rounded-full p-1 text-white/40 transition hover:text-[#FC7019] ${
+                        isActive ? "hover:bg-black/10" : "hover:bg-black/30"
+                      }`}
+                      aria-label="Delete conversation"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default ChatSidebar;

--- a/client/app/ai/components/ChatSidebar.tsx
+++ b/client/app/ai/components/ChatSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ConversationPreview } from "./types";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus, Trash2, X } from "lucide-react";
 
 interface ChatSidebarProps {
   conversations: ConversationPreview[];
@@ -42,7 +42,7 @@ const ChatSidebar = ({
             className="text-gray-500 transition hover:text-gray-700 lg:hidden"
             aria-label="Close sidebar"
           >
-            X
+            <X className="h-5 w-5" />
           </button>
         </div>
 

--- a/client/app/ai/components/ChatSidebar.tsx
+++ b/client/app/ai/components/ChatSidebar.tsx
@@ -24,22 +24,22 @@ const ChatSidebar = ({
 }: ChatSidebarProps) => {
   return (
     <aside
-      className={`fixed inset-y-0 left-0 z-30 w-72 bg-[#0E0E0E] border-r border-white/10 transition-transform duration-300 lg:relative lg:translate-x-0 ${
+      className={`fixed inset-y-0 left-0 z-30 w-72 bg-[#FFFAF5] border-r border-[#F2D8C3] shadow-lg transition-transform duration-300 lg:relative lg:translate-x-0 ${
         isOpen ? "translate-x-0" : "-translate-x-full"
       }`}
     >
       <div className="flex h-full flex-col">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+        <div className="flex items-center justify-between border-b border-[#F2D8C3] bg-white/80 px-5 py-4">
           <div>
-            <p className="text-xs font-medium uppercase text-white/60 tracking-[0.2em]">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-[#FC7019]">
               IslaGrid
             </p>
-            <h2 className="text-lg font-semibold text-white">IslaBot AI</h2>
+            <h2 className="text-lg font-semibold text-gray-900">IslaBot AI</h2>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="lg:hidden text-white/50 hover:text-white"
+            className="text-gray-500 transition hover:text-gray-700 lg:hidden"
             aria-label="Close sidebar"
           >
             X
@@ -50,7 +50,7 @@ const ChatSidebar = ({
           <button
             type="button"
             onClick={onCreateConversation}
-            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#FC7019] px-3 py-2 text-sm font-semibold text-black transition hover:bg-white"
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#FC7019] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#E8620F]"
           >
             <Plus className="h-4 w-4" />
             New Conversation
@@ -69,8 +69,8 @@ const ChatSidebar = ({
                     onClick={() => onSelectConversation(conversation.id)}
                     className={`group flex w-full items-start justify-between rounded-xl px-4 py-3 text-left transition ${
                       isActive
-                        ? "bg-white text-black"
-                        : "bg-white/5 text-white hover:bg-white/10"
+                        ? "bg-[#FC7019] text-white shadow-md"
+                        : "bg-white text-gray-800 shadow-sm hover:bg-[#FFF1E6]"
                     }`}
                   >
                     <div className="flex-1">
@@ -79,15 +79,29 @@ const ChatSidebar = ({
                           {conversation.title}
                         </span>
                         {conversation.pinned && (
-                          <span className="rounded-full bg-[#FC7019]/20 px-2 text-[10px] font-semibold uppercase tracking-wide text-[#FC7019]">
+                          <span
+                            className={`rounded-full px-2 text-[10px] font-semibold uppercase tracking-wide ${
+                              isActive
+                                ? "bg-white/30 text-white"
+                                : "bg-[#FFE2C9] text-[#FC7019]"
+                            }`}
+                          >
                             Pinned
                           </span>
                         )}
                       </div>
-                      <p className="mt-1 line-clamp-2 text-xs opacity-70">
+                      <p
+                        className={`mt-1 line-clamp-2 text-xs ${
+                          isActive ? "text-white/80" : "text-gray-500"
+                        }`}
+                      >
                         {conversation.lastMessage}
                       </p>
-                      <p className="mt-2 text-[11px] uppercase tracking-wider text-white/50">
+                      <p
+                        className={`mt-2 text-[11px] uppercase tracking-wider ${
+                          isActive ? "text-white/70" : "text-gray-400"
+                        }`}
+                      >
                         {conversation.updatedAt}
                       </p>
                     </div>
@@ -97,8 +111,10 @@ const ChatSidebar = ({
                         event.stopPropagation();
                         onDeleteConversation(conversation.id);
                       }}
-                      className={`rounded-full p-1 text-white/40 transition hover:text-[#FC7019] ${
-                        isActive ? "hover:bg-black/10" : "hover:bg-black/30"
+                      className={`rounded-full p-1 transition ${
+                        isActive
+                          ? "text-white/80 hover:bg-white/20 hover:text-white"
+                          : "text-gray-400 hover:bg-[#FFE2C9] hover:text-[#FC7019]"
                       }`}
                       aria-label="Delete conversation"
                     >

--- a/client/app/ai/components/types.ts
+++ b/client/app/ai/components/types.ts
@@ -1,0 +1,22 @@
+export type ChatRole = "user" | "assistant";
+
+export interface ChatReference {
+  title?: string;
+  url: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  usedSearch?: boolean;
+  references?: ChatReference[];
+}
+
+export interface ConversationPreview {
+  id: string;
+  title: string;
+  lastMessage: string;
+  updatedAt: string;
+  pinned?: boolean;
+}

--- a/client/app/ai/page.tsx
+++ b/client/app/ai/page.tsx
@@ -176,6 +176,8 @@ const AiPage = () => {
       return;
     }
 
+    const conversationId = currentConversationId;
+
     const userMessage: ChatMessage = {
       id: `user-${Date.now()}`,
       role: "user",
@@ -183,14 +185,14 @@ const AiPage = () => {
     };
 
     setMessagesByConversation((previous) => {
-      const current = previous[currentConversationId] ?? [];
+      const current = previous[conversationId] ?? [];
       return {
         ...previous,
-        [currentConversationId]: [...current, userMessage],
+        [conversationId]: [...current, userMessage],
       };
     });
 
-    updateConversationPreview(currentConversationId, messageInput.trim());
+    updateConversationPreview(conversationId, messageInput.trim());
     setMessageInput("");
     setIsLoading(true);
 
@@ -203,16 +205,13 @@ const AiPage = () => {
           shouldUseSearch
         );
         setMessagesByConversation((previous) => {
-          const current = previous[currentConversationId] ?? [];
+          const current = previous[conversationId] ?? [];
           return {
             ...previous,
-            [currentConversationId]: [...current, assistantMessage],
+            [conversationId]: [...current, assistantMessage],
           };
         });
-        updateConversationPreview(
-          currentConversationId,
-          assistantMessage.content
-        );
+        updateConversationPreview(conversationId, assistantMessage.content);
         setIsLoading(false);
       },
       shouldUseSearch ? 1200 : 800
@@ -237,7 +236,7 @@ const AiPage = () => {
   };
 
   return (
-  <div className="relative flex h-screen bg-linear-to-br from-white via-[#FFF5EB] to-white text-gray-900">
+    <div className="relative flex h-screen bg-linear-to-br from-white via-[#FFF5EB] to-white text-gray-900">
       {sidebarOpen && (
         <div
           className="fixed inset-0 z-20 bg-black/60 lg:hidden"

--- a/client/app/ai/page.tsx
+++ b/client/app/ai/page.tsx
@@ -237,7 +237,7 @@ const AiPage = () => {
   };
 
   return (
-  <div className="relative flex h-screen bgbg-linear-to-brm-white via-[#FFF5EB] to-white text-gray-900">
+  <div className="relative flex h-screen bg-linear-to-br from-white via-[#FFF5EB] to-white text-gray-900">
       {sidebarOpen && (
         <div
           className="fixed inset-0 z-20 bg-black/60 lg:hidden"

--- a/client/app/ai/page.tsx
+++ b/client/app/ai/page.tsx
@@ -140,19 +140,27 @@ const AiPage = () => {
 
     setMessagesByConversation((previous) => {
       const { [conversationId]: _removed, ...rest } = previous;
+      let newMessagesByConversation;
       if (Object.keys(rest).length > 0) {
-        return rest;
+        newMessagesByConversation = rest;
+      } else {
+        newMessagesByConversation = {
+          welcome: [DEFAULT_ASSISTANT_MESSAGE],
+        };
       }
 
-      return {
-        welcome: [DEFAULT_ASSISTANT_MESSAGE],
-      };
-    });
+      // If the deleted conversation was the current one, set a valid fallback ID
+      if (conversationId === currentConversationId) {
+        // Find the first fallbackConversations ID that exists in newMessagesByConversation
+        const fallbackId = fallbackConversations.find(conv => newMessagesByConversation.hasOwnProperty(conv.id))?.id
+          ?? Object.keys(newMessagesByConversation)[0]
+          ?? "welcome";
+        setCurrentConversationId(fallbackId);
+        setIsLoading(false);
+      }
 
-    if (conversationId === currentConversationId) {
-      setCurrentConversationId(fallbackConversations[0]?.id ?? "welcome");
-      setIsLoading(false);
-    }
+      return newMessagesByConversation;
+    });
   };
 
   const simulateAssistantReply = (

--- a/client/app/ai/page.tsx
+++ b/client/app/ai/page.tsx
@@ -1,9 +1,310 @@
-import React from 'react'
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { RotateCcw, Sparkles } from "lucide-react";
+import ChatSidebar from "./components/ChatSidebar";
+import ChatHeader from "./components/ChatHeader";
+import ChatMessageList from "./components/ChatMessageList";
+import ChatInput from "./components/ChatInput";
+import type { ChatMessage, ConversationPreview } from "./components/types";
+
+const DEFAULT_ASSISTANT_MESSAGE: ChatMessage = {
+  id: "assistant-welcome",
+  role: "assistant",
+  content:
+    "Hello! I am IslaBot, your guide to the IslaGrid Meralco Community Energy Ecosystem. Ask me how your barangay can generate, distribute, and benefit from community-owned renewable power.",
+};
+
+const SUGGESTED_PROMPTS = [
+  "Summarize how IslaGrid expands the net-metering program for communities.",
+  "What data do we need to generate a proposal for a river-based micro hydro plant?",
+  "Explain how revenue distribution works with NFC profit cards.",
+  "Outline the AI-Driven Energy Design Studio workflow from input to output.",
+];
+
+type ConversationState = Record<string, ChatMessage[]>;
 
 const AiPage = () => {
-  return (
-    <div>AiPage</div>
-  )
-}
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [webSearchEnabled, setWebSearchEnabled] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [messageInput, setMessageInput] = useState("");
+  const [currentConversationId, setCurrentConversationId] = useState("welcome");
+  const [conversations, setConversations] = useState<ConversationPreview[]>([
+    {
+      id: "welcome",
+      title: "Fresh Chat",
+      lastMessage: "Ask IslaBot how IslaGrid powers communities.",
+      updatedAt: "Just now",
+      pinned: true,
+    },
+  ]);
+  const [messagesByConversation, setMessagesByConversation] =
+    useState<ConversationState>({
+      welcome: [DEFAULT_ASSISTANT_MESSAGE],
+    });
 
-export default AiPage
+  const currentMessages = useMemo(() => {
+    return messagesByConversation[currentConversationId] ?? [];
+  }, [messagesByConversation, currentConversationId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleResize = () => {
+      setSidebarOpen(window.innerWidth >= 1024);
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const updateConversationPreview = (
+    conversationId: string,
+    lastMessage: string
+  ) => {
+    setConversations((previous) => {
+      const existing = previous.find(
+        (conversation) => conversation.id === conversationId
+      );
+      const updatedConversation: ConversationPreview = existing
+        ? {
+            ...existing,
+            lastMessage,
+            updatedAt: "Just now",
+          }
+        : {
+            id: conversationId,
+            title: "New Conversation",
+            lastMessage,
+            updatedAt: "Just now",
+          };
+
+      const withoutCurrent = previous.filter(
+        (conversation) => conversation.id !== conversationId
+      );
+      return [updatedConversation, ...withoutCurrent];
+    });
+  };
+
+  const handleSelectConversation = (conversationId: string) => {
+    setCurrentConversationId(conversationId);
+    if (typeof window !== "undefined" && window.innerWidth < 1024) {
+      setSidebarOpen(false);
+    }
+  };
+
+  const handleCreateConversation = () => {
+    const newId = `conversation-${Date.now()}`;
+    const newPreview: ConversationPreview = {
+      id: newId,
+      title: "Untitled Chat",
+      lastMessage: "Start planning your community energy project.",
+      updatedAt: "Just now",
+    };
+
+    setConversations((previous) => [newPreview, ...previous]);
+    setMessagesByConversation((previous) => ({
+      ...previous,
+      [newId]: [DEFAULT_ASSISTANT_MESSAGE],
+    }));
+    setCurrentConversationId(newId);
+    setMessageInput("");
+    if (typeof window !== "undefined" && window.innerWidth < 1024) {
+      setSidebarOpen(false);
+    }
+  };
+
+  const handleDeleteConversation = (conversationId: string) => {
+    const remainingPreviews = conversations.filter(
+      (conversation) => conversation.id !== conversationId
+    );
+
+    const fallbackConversations =
+      remainingPreviews.length > 0
+        ? remainingPreviews
+        : [
+            {
+              id: "welcome",
+              title: "Fresh Chat",
+              lastMessage: "Ask IslaBot how IslaGrid powers communities.",
+              updatedAt: "Just now",
+              pinned: true,
+            },
+          ];
+
+    setConversations(fallbackConversations);
+
+    setMessagesByConversation((previous) => {
+      const { [conversationId]: _removed, ...rest } = previous;
+      if (Object.keys(rest).length > 0) {
+        return rest;
+      }
+
+      return {
+        welcome: [DEFAULT_ASSISTANT_MESSAGE],
+      };
+    });
+
+    if (conversationId === currentConversationId) {
+      setCurrentConversationId(fallbackConversations[0]?.id ?? "welcome");
+      setIsLoading(false);
+    }
+  };
+
+  const simulateAssistantReply = (
+    prompt: string,
+    useSearch: boolean
+  ): ChatMessage => {
+    const trimmed = prompt.trim();
+    const topic = trimmed.length > 0 ? trimmed : "your request";
+    const snippet = topic.length > 80 ? `${topic.slice(0, 77)}...` : topic;
+
+    return {
+      id: `assistant-${Date.now()}`,
+      role: "assistant",
+      usedSearch: useSearch,
+      content: `Here is what I can share about "${snippet}":\n\n1. Generation — assess solar, hydro, wind, or hybrid potential using the AI-Driven Energy Design Studio.\n2. Distribution — connect community-owned assets to Meralco's grid with smart metering for transparent exports.\n3. Benefit Sharing — route revenues into NFC profit cards so residents experience direct economic uplift.\n\nProvide location, resource data, demand profile, and community stakeholders if you want me to draft a tailored IslaGrid rollout.`,
+    };
+  };
+
+  const handleSendMessage = () => {
+    if (messageInput.trim().length === 0 || isLoading) {
+      return;
+    }
+
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content: messageInput.trim(),
+    };
+
+    setMessagesByConversation((previous) => {
+      const current = previous[currentConversationId] ?? [];
+      return {
+        ...previous,
+        [currentConversationId]: [...current, userMessage],
+      };
+    });
+
+    updateConversationPreview(currentConversationId, messageInput.trim());
+    setMessageInput("");
+    setIsLoading(true);
+
+    const shouldUseSearch = webSearchEnabled;
+
+    window.setTimeout(
+      () => {
+        const assistantMessage = simulateAssistantReply(
+          userMessage.content,
+          shouldUseSearch
+        );
+        setMessagesByConversation((previous) => {
+          const current = previous[currentConversationId] ?? [];
+          return {
+            ...previous,
+            [currentConversationId]: [...current, assistantMessage],
+          };
+        });
+        updateConversationPreview(
+          currentConversationId,
+          assistantMessage.content
+        );
+        setIsLoading(false);
+      },
+      shouldUseSearch ? 1200 : 800
+    );
+  };
+
+  const handleSuggestionPick = (suggestion: string) => {
+    setMessageInput(suggestion);
+  };
+
+  const handleResetConversation = () => {
+    setMessagesByConversation((previous) => ({
+      ...previous,
+      [currentConversationId]: [DEFAULT_ASSISTANT_MESSAGE],
+    }));
+    updateConversationPreview(
+      currentConversationId,
+      "Ask IslaBot how IslaGrid powers communities."
+    );
+    setMessageInput("");
+    setIsLoading(false);
+  };
+
+  return (
+    <div className="relative flex h-screen bg-linear-to-br from-black via-[#141414] to-black text-white">
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black/60 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      <ChatSidebar
+        conversations={conversations}
+        currentConversationId={currentConversationId}
+        onSelectConversation={handleSelectConversation}
+        onCreateConversation={handleCreateConversation}
+        onDeleteConversation={handleDeleteConversation}
+        isOpen={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+      />
+
+      <div className="flex flex-1 flex-col">
+        <ChatHeader
+          title="IslaBot AI"
+          subtitle="Community Energy Navigation"
+          onToggleSidebar={() => setSidebarOpen((previous) => !previous)}
+          actions={
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleResetConversation}
+                className="flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/70 transition hover:border-[#FC7019] hover:text-white"
+              >
+                <RotateCcw className="h-3.5 w-3.5" /> Reset
+              </button>
+              <div className="hidden items-center gap-2 rounded-full border border-[#FC7019]/40 bg-[#FC7019]/10 px-4 py-1 text-xs font-semibold uppercase tracking-wider text-[#FC7019] md:flex">
+                <Sparkles className="h-3.5 w-3.5" /> IslaGrid Trusted
+              </div>
+            </div>
+          }
+        />
+
+        <ChatMessageList
+          messages={currentMessages}
+          isLoading={isLoading}
+          suggestions={SUGGESTED_PROMPTS}
+          onSuggestionPick={handleSuggestionPick}
+          onCopyMessage={(messageId) => {
+            const message = currentMessages.find(
+              (item) => item.id === messageId
+            );
+            if (message) {
+              window.navigator.clipboard
+                .writeText(message.content)
+                .catch(() => {});
+            }
+          }}
+          webSearchEnabled={webSearchEnabled}
+        />
+
+        <ChatInput
+          value={messageInput}
+          onChange={setMessageInput}
+          onSend={handleSendMessage}
+          isLoading={isLoading}
+          webSearchEnabled={webSearchEnabled}
+          onToggleWebSearch={() => setWebSearchEnabled((previous) => !previous)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AiPage;

--- a/client/app/ai/page.tsx
+++ b/client/app/ai/page.tsx
@@ -237,7 +237,7 @@ const AiPage = () => {
   };
 
   return (
-    <div className="relative flex h-screen bg-linear-to-br from-black via-[#141414] to-black text-white">
+  <div className="relative flex h-screen bgbg-linear-to-brm-white via-[#FFF5EB] to-white text-gray-900">
       {sidebarOpen && (
         <div
           className="fixed inset-0 z-20 bg-black/60 lg:hidden"
@@ -265,11 +265,11 @@ const AiPage = () => {
               <button
                 type="button"
                 onClick={handleResetConversation}
-                className="flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/70 transition hover:border-[#FC7019] hover:text-white"
+                className="flex items-center gap-2 rounded-full border border-[#F2D8C3] px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-600 transition hover:border-[#FC7019] hover:text-[#FC7019]"
               >
                 <RotateCcw className="h-3.5 w-3.5" /> Reset
               </button>
-              <div className="hidden items-center gap-2 rounded-full border border-[#FC7019]/40 bg-[#FC7019]/10 px-4 py-1 text-xs font-semibold uppercase tracking-wider text-[#FC7019] md:flex">
+              <div className="hidden items-center gap-2 rounded-full border border-[#FC7019]/30 bg-[#FFF5EB] px-4 py-1 text-xs font-semibold uppercase tracking-wider text-[#FC7019] md:flex">
                 <Sparkles className="h-3.5 w-3.5" /> IslaGrid Trusted
               </div>
             </div>


### PR DESCRIPTION
This pull request introduces a new set of modular, client-side React components for an AI chat interface, along with supporting type definitions. The changes establish a flexible and user-friendly chat UI, including a sidebar for conversation management, a message list with assistant/user roles, an input area with web search toggling, and a reusable header component. These components are designed for clarity, maintainability, and ease of extension.

**New AI Chat UI Components:**

* Introduced `ChatHeader`, a reusable header component supporting a title, subtitle, sidebar toggle, and custom actions.
* Added `ChatSidebar` for managing and switching between conversations, including support for creating, deleting, and pinning conversations.
* Implemented `ChatMessageList` to display chat messages with assistant/user distinction, message copying, references, and loading states, as well as onboarding suggestions when the chat is empty.
* Created `ChatInput`, an input area with autosizing textarea, send button, and a toggle for enabling/disabling web search, including keyboard shortcuts and loading state handling.

**Type Definitions:**

* Added a new `types.ts` file defining TypeScript types and interfaces for chat roles, messages, references, and conversation previews to ensure type safety and consistency across components.